### PR TITLE
Fix invite link to Telegram chat

### DIFF
--- a/lib/redmine2chat/platforms/telegram.rb
+++ b/lib/redmine2chat/platforms/telegram.rb
@@ -81,6 +81,8 @@ module Redmine2chat::Platforms
 
     def convert_link(link)
       invite_id = Addressable::URI.parse(link).request_uri.split('/').last
+      # Trim leading plus sign for compatibility with Telegram API 5.4
+      invite_id = invite_id[1..-1] if invite_id[0] == "+"
       "#{Setting.protocol}://#{Setting.host_name}/tg/#{invite_id}"
     end
   end


### PR DESCRIPTION
Since [Telegram API 5.4](https://core.telegram.org/bots/api-changelog#november-5-2021) invite link to chat contains leading plus sign. For example, API give `invite_link` like a `https://t.me/+LINK_ID`. This request redirects to `tg://join?invite=LINK_ID` without plus sign. This changes broke `/tg/LINK_ID` action.
